### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dioxus.yml
+++ b/.github/workflows/dioxus.yml
@@ -1,5 +1,8 @@
 name: Build and publish Cantara
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [master]


### PR DESCRIPTION
Potential fix for [https://github.com/CantaraProject/Cantara/security/code-scanning/1](https://github.com/CantaraProject/Cantara/security/code-scanning/1)

To fix the issue, add a `permissions` block to the root of the workflow file. This block will explicitly define the permissions required for the workflow, ensuring that the `GITHUB_TOKEN` has the least privilege necessary. Based on the workflow's operations, the `contents: read` permission is sufficient for reading repository contents, and no write permissions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
