### PR TITLE
Implement live update for running presentations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,6 +621,7 @@ dependencies = [
  "serde_json",
  "sys-locale",
  "tempfile",
+ "uuid",
  "web-sys",
  "webpki-root-certs",
  "zip",
@@ -6612,6 +6613,7 @@ version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
 dependencies = [
+ "getrandom 0.4.1",
  "js-sys",
  "serde_core",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ dioxus-free-icons = { version = "0.10.0", features = [
 rust-i18n = "3.1.5"
 serde = "1.0.228"
 serde_json = "1.0.145"
+uuid = { version = "1", features = ["v4", "serde"] }
 sys-locale = "=0.3.2"
 
 # Cantara libraries

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ base64 = "0.22.1"
 # lopdf -> rand -> rand_core -> getrandom 0.3, zip -> getrandom 0.4
 getrandom = { version = "0.3", features = ["wasm_js"] }
 getrandom_0_4 = { package = "getrandom", version = "0.4", features = ["wasm_js"] }
+uuid = { version = "1", features = ["js"] }
 
 [features]
 default = ["desktop"]

--- a/assets/main.css
+++ b/assets/main.css
@@ -26,6 +26,28 @@ body {
     padding: 0 !important;
 }
 
+/* Running presentation indicator bar */
+.running-presentation-bar {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.4rem 1rem;
+    background-color: var(--pico-primary-background);
+    color: var(--pico-primary-inverse);
+    font-size: 0.9rem;
+}
+
+.running-presentation-bar span {
+    flex: 1;
+}
+
+.running-presentation-bar button {
+    margin: 0;
+    padding: 0.25rem 0.75rem;
+    font-size: 0.85rem;
+    white-space: nowrap;
+}
+
 /* Fixed bottom bar */
 .bottom-bar {
     width: 100%;

--- a/assets/pdf_render_inline.js
+++ b/assets/pdf_render_inline.js
@@ -36,11 +36,19 @@
         // 5. Find the canvas element
         var canvas = document.getElementById(__CANVAS_ID__);
         if (!canvas) {
-            console.error('PDF canvas not found:', __CANVAS_ID__);
+            // Canvas was removed from DOM (component unmounted) — silently exit
             return;
         }
 
-        // 6. Determine available space from the presentation container
+        // 6. Cancel any in-progress render for this canvas
+        if (!window.__pdfRenderTasks) window.__pdfRenderTasks = {};
+        var prevTask = window.__pdfRenderTasks[__CANVAS_ID__];
+        if (prevTask) {
+            try { prevTask.cancel(); } catch(_) {}
+            delete window.__pdfRenderTasks[__CANVAS_ID__];
+        }
+
+        // 7. Determine available space from the presentation container
         var el = canvas.closest('.presentation') || canvas.parentElement;
         var w = el ? el.clientWidth : 0;
         var h = el ? el.clientHeight : 0;
@@ -54,7 +62,7 @@
         if (w <= 0) w = window.innerWidth || 800;
         if (h <= 0) h = window.innerHeight || 600;
 
-        // 7. Scale the page to fit (uniform, no stretching)
+        // 8. Scale the page to fit (uniform, no stretching)
         var unscaledVp = page.getViewport({ scale: 1 });
         var scale = Math.min(w / unscaledVp.width, h / unscaledVp.height);
         var vp = page.getViewport({ scale: scale });
@@ -62,9 +70,19 @@
         canvas.width = vp.width;
         canvas.height = vp.height;
 
-        // 8. Render
-        await page.render({ canvasContext: canvas.getContext('2d'), viewport: vp }).promise;
+        // 9. Re-check canvas is still in DOM right before render
+        if (!document.getElementById(__CANVAS_ID__)) {
+            return;
+        }
+
+        // 10. Render, tracking the task so it can be cancelled
+        var renderTask = page.render({ canvasContext: canvas.getContext('2d'), viewport: vp });
+        window.__pdfRenderTasks[__CANVAS_ID__] = renderTask;
+        await renderTask.promise;
+        delete window.__pdfRenderTasks[__CANVAS_ID__];
     } catch (e) {
+        // Suppress RenderingCancelledException — this is expected during live updates
+        if (e && e.name === 'RenderingCancelledException') return;
         console.error('PDF render error:', e);
     }
 })();

--- a/locales/app.yml
+++ b/locales/app.yml
@@ -74,6 +74,15 @@ selection:
       zoom_in:
         en: Zoom in
         de: Einzoomen
+  presentation_running:
+    en: A presentation is currently running.
+    de: Eine Präsentation läuft gerade.
+  update_presentation:
+    en: Update Presentation
+    de: Präsentation aktualisieren
+  return_to_presenter:
+    en: Return to Presenter Console
+    de: Zurück zur Moderatorenkonsole
   markdown:
     add_text:
       en: Add Markdown Text
@@ -428,6 +437,9 @@ presenter:
   quit:
     en: Quit
     de: Beenden
+  edit_selection:
+    en: Edit Selection
+    de: Auswahl bearbeiten
   empty_slide:
     en: (Empty slide)
     de: (Leere Folie)

--- a/src/components/presentation_components.rs
+++ b/src/components/presentation_components.rs
@@ -13,8 +13,8 @@ use crate::logic::presentation::{get_markdown_html, get_picture_path};
 use crate::logic::settings::{CssSize, HorizontalAlign, VerticalAlign};
 #[cfg(target_arch = "wasm32")]
 use crate::logic::sync::{
-    SYNC_KEY_ACTIVE, SYNC_KEY_POSITION, SYNC_KEY_POSITION_FROM_CONSOLE, SYNC_KEY_PRESENTATION,
-    SYNC_KEY_QUIT,
+    SYNC_KEY_ACTIVE, SYNC_KEY_FILES, SYNC_KEY_POSITION, SYNC_KEY_POSITION_FROM_CONSOLE,
+    SYNC_KEY_PRESENTATION, SYNC_KEY_QUIT,
 };
 use crate::{
     MAIN_CSS,
@@ -47,21 +47,49 @@ pub fn PresentationPage() -> Element {
     let mut running_presentations: Signal<Vec<RunningPresentation>> = use_context();
 
     // On web, check if this is a synced new-tab presentation (opened by the presenter console).
-    // In that case the running_presentations signal will be empty, and we load data from localStorage.
+    // In that case the running_presentations signal will be empty, and we load data from
+    // localStorage. The data is stored in a local variable first; it is pushed into the
+    // shared signal via use_effect (after rendering completes) to avoid writing to a signal
+    // during the render phase, which causes "RefCell already borrowed" panics on web.
     #[cfg(target_arch = "wasm32")]
-    {
-        if running_presentations.read().is_empty() {
-            // Try to load synced presentation data from localStorage
-            if let Some(json) = web_sys::window()
+    let synced_rp: Option<RunningPresentation> = {
+        if running_presentations.peek().is_empty() {
+            // Restore VFS file data (e.g. PDFs) from localStorage so that
+            // PdfPageCanvas can read them. This must happen before the
+            // presentation renders.
+            if let Some(files_json) = web_sys::window()
+                .and_then(|w| w.local_storage().ok().flatten())
+                .and_then(|s| s.get_item(SYNC_KEY_FILES).ok().flatten())
+            {
+                use crate::logic::settings::RepositoryType;
+                use std::collections::HashMap;
+
+                if let Ok(files) = serde_json::from_str::<HashMap<String, String>>(&files_json) {
+                    for (path, b64) in &files {
+                        if let Ok(bytes) = base64::Engine::decode(
+                            &base64::engine::general_purpose::STANDARD,
+                            b64,
+                        ) {
+                            RepositoryType::store_web_file(path, bytes);
+                        }
+                    }
+                }
+                // Clean up to free localStorage space
+                let _ = web_sys::window()
+                    .and_then(|w| w.local_storage().ok().flatten())
+                    .map(|s| s.remove_item(SYNC_KEY_FILES));
+            }
+
+            web_sys::window()
                 .and_then(|w| w.local_storage().ok().flatten())
                 .and_then(|s| s.get_item(SYNC_KEY_PRESENTATION).ok().flatten())
-            {
-                if let Ok(rp) = serde_json::from_str::<RunningPresentation>(&json) {
-                    running_presentations.write().push(rp);
-                }
-            }
+                .and_then(|json| serde_json::from_str(&json).ok())
+        } else {
+            None
         }
-    }
+    };
+    #[cfg(not(target_arch = "wasm32"))]
+    let synced_rp: Option<RunningPresentation> = None;
 
     // On non-desktop builds, navigator() is used to detect whether this is a routed page
     // and to navigate back on quit. On desktop this page always runs as a standalone window
@@ -81,8 +109,9 @@ pub fn PresentationPage() -> Element {
     #[cfg(not(target_arch = "wasm32"))]
     let is_synced_tab = false;
 
-    // If there's still no presentation data, close the window (desktop) or show an error
-    if running_presentations.read().is_empty() {
+    // If there's still no presentation data (and no synced data from localStorage),
+    // close the window (desktop) or show an error.
+    if running_presentations.peek().is_empty() && synced_rp.is_none() {
         #[cfg(feature = "desktop")]
         dioxus::desktop::window().close();
 
@@ -95,8 +124,10 @@ pub fn PresentationPage() -> Element {
         };
     }
 
+    let initial_rp = synced_rp
+        .unwrap_or_else(|| running_presentations.peek().first().unwrap().clone());
     let mut running_presentation: Signal<RunningPresentation> =
-        use_signal(move || running_presentations.get(0).unwrap().clone());
+        use_signal(move || initial_rp);
 
     // When this window/component is destroyed (e.g. user closes the window),
     // clear the shared running presentations so the presenter console also closes.
@@ -107,6 +138,16 @@ pub fn PresentationPage() -> Element {
     use_drop(move || {
         if let Ok(mut guard) = running_presentations.try_write() {
             guard.clear();
+        }
+    });
+
+    // Deferred: for synced new-tab presentations, push the localStorage data
+    // into the shared signal after rendering (not during) so other subscribers
+    // (e.g. the shared→local effect) can see it.
+    #[cfg(target_arch = "wasm32")]
+    use_effect(move || {
+        if is_synced_tab && running_presentations.peek().is_empty() {
+            running_presentations.write().push(running_presentation.peek().clone());
         }
     });
 
@@ -203,6 +244,11 @@ pub fn PresentationPage() -> Element {
     use_effect(move || {
         let current = running_presentations.read();
         if current.is_empty() {
+            // Drop the read guard BEFORE navigating — on web (single VirtualDom),
+            // nav.replace() triggers a synchronous re-render/diff that would
+            // attempt to borrow the same RefCell, causing a "RefCell already
+            // borrowed" panic.
+            drop(current);
             if is_routed {
                 nav.replace(crate::Route::Selection {});
             }
@@ -210,7 +256,9 @@ pub fn PresentationPage() -> Element {
         }
         if let Some(rp) = current.first() {
             if !rp.eq_ignoring_scroll(&running_presentation.peek()) {
-                running_presentation.set(rp.clone());
+                let rp = rp.clone();
+                drop(current);
+                running_presentation.set(rp);
             }
         }
     });
@@ -313,6 +361,7 @@ pub fn PresentationPage() -> Element {
                     let _ = s.remove_item(SYNC_KEY_PRESENTATION);
                     let _ = s.remove_item(SYNC_KEY_POSITION);
                     let _ = s.remove_item(SYNC_KEY_POSITION_FROM_CONSOLE);
+                    let _ = s.remove_item(SYNC_KEY_FILES);
                 });
         }
         running_presentations.write().clear();

--- a/src/components/presentation_components.rs
+++ b/src/components/presentation_components.rs
@@ -7,6 +7,7 @@ use dioxus::prelude::*;
 use regex::Regex;
 use rgb::RGBA8;
 use rust_i18n::t;
+use uuid::Uuid;
 
 use crate::logic::css::{CssHandler, PlaceItems};
 use crate::logic::presentation::{get_markdown_html, get_picture_path};
@@ -333,6 +334,26 @@ pub fn PresentationPage() -> Element {
                         last_sync_json.set(json.clone());
                         if let Ok(rp) = serde_json::from_str::<RunningPresentation>(&json) {
                             if *running_presentation.peek() != rp {
+                                // Load any new VFS files (e.g. PDFs) that the
+                                // update_presentation call stored in localStorage
+                                if let Some(files_json) = web_sys::window()
+                                    .and_then(|w| w.local_storage().ok().flatten())
+                                    .and_then(|s| s.get_item(SYNC_KEY_FILES).ok().flatten())
+                                {
+                                    use crate::logic::settings::RepositoryType;
+                                    use std::collections::HashMap;
+
+                                    if let Ok(files) = serde_json::from_str::<HashMap<String, String>>(&files_json) {
+                                        for (path, b64) in &files {
+                                            if let Ok(bytes) = BASE64.decode(b64) {
+                                                RepositoryType::store_web_file(path, bytes);
+                                            }
+                                        }
+                                    }
+                                    let _ = web_sys::window()
+                                        .and_then(|w| w.local_storage().ok().flatten())
+                                        .map(|s| s.remove_item(SYNC_KEY_FILES));
+                                }
                                 running_presentation.set(rp);
                             }
                         }
@@ -715,20 +736,22 @@ pub fn PresentationRendererComponent(
                 style: background_css()
             }
             if presentation_is_visible() {
-                {
-                    let slide_content = current_slide.read().clone().unwrap().slide_content.clone();
-                    let container_style = slide_container_style(&slide_content);
-                    let tc = transition_class();
+                if let Some(slide) = current_slide.read().clone() {
+                    {
+                        let slide_content = slide.slide_content.clone();
+                        let container_style = slide_container_style(&slide_content);
+                        let tc = transition_class();
 
-                    rsx! {
-                        div {
-                            class: "slide-container {tc}",
-                            style: "{container_style}",
-                            key: "{current_slide_number}",
-                            SlideContentRenderer {
-                                slide_content: slide_content,
-                                pds: current_pds(),
-                                running_presentation: Some(running_presentation),
+                        rsx! {
+                            div {
+                                class: "slide-container {tc}",
+                                style: "{container_style}",
+                                key: "{current_slide_number}",
+                                SlideContentRenderer {
+                                    slide_content: slide_content,
+                                    pds: current_pds(),
+                                    running_presentation: Some(running_presentation),
+                                }
                             }
                         }
                     }
@@ -1165,10 +1188,15 @@ fn SimplePictureSlideComponent(picture_slide: SimplePictureSlide) -> Element {
 /// is self-contained and does not depend on external script loading order.
 #[component]
 fn PdfPageCanvas(pdf_path: String, page_num: u32) -> Element {
+    // Use a unique ID per mount cycle to prevent conflicts when the component
+    // unmounts and remounts during live updates. Old async render tasks will
+    // target a canvas ID that no longer exists in the DOM and exit gracefully.
+    let mount_id = use_hook(Uuid::new_v4);
     let canvas_id = format!(
-        "pdf-canvas-{}-{}",
+        "pdf-canvas-{}-{}-{}",
         pdf_path.replace(['/', '\\', '.', ' ', ':'], "-"),
-        page_num
+        page_num,
+        mount_id.as_simple()
     );
 
     // Read the PDF file and encode it as base64 so we can hand it to JS
@@ -1210,6 +1238,11 @@ fn PdfPageCanvas(pdf_path: String, page_num: u32) -> Element {
                 let b64 = base64_data.read().clone();
                 let pdfjs_url = pdfjs_url.clone();
                 let worker_url = worker_url.clone();
+                // Skip rendering if the PDF data is empty (file not in VFS)
+                if b64.is_empty() {
+                    log::warn!("PDF data empty for {}, skipping render", pdf_path);
+                    return;
+                }
                 spawn(async move {
                     // Use serde_json to safely escape all string values for JavaScript
                     let js_pdfjs_url = serde_json::to_string(&pdfjs_url).unwrap_or_default();

--- a/src/components/presenter_console_components.rs
+++ b/src/components/presenter_console_components.rs
@@ -276,7 +276,19 @@ pub fn PresenterConsolePage() -> Element {
 
             PresenterControlBar {
                 running_presentation: running_presentation,
-                on_quit: move |_| quit_presentation()
+                on_quit: move |_| quit_presentation(),
+                on_edit_selection: {
+                    if is_main_window {
+                        let nav_clone = nav.clone();
+                        Some(EventHandler::new(move |_: ()| {
+                            if let Some(ref n) = nav_clone {
+                                n.push(crate::Route::Selection {});
+                            }
+                        }))
+                    } else {
+                        None
+                    }
+                },
             }
         }
     }
@@ -681,6 +693,8 @@ fn PresenterPreviewPanel(running_presentation: Signal<RunningPresentation>) -> E
 fn PresenterControlBar(
     running_presentation: Signal<RunningPresentation>,
     on_quit: EventHandler<()>,
+    #[props(default)]
+    on_edit_selection: Option<EventHandler<()>>,
 ) -> Element {
     let rp = running_presentation.read();
     let current_total = rp
@@ -743,6 +757,18 @@ fn PresenterControlBar(
                         running_presentation.write().toggle_black_screen();
                     },
                     { t!("presenter.black_screen").to_string() }
+                }
+                if let Some(ref handler) = on_edit_selection {
+                    button {
+                        class: "outline secondary",
+                        onclick: {
+                            let handler = handler.clone();
+                            move |_| {
+                                handler.call(());
+                            }
+                        },
+                        { t!("presenter.edit_selection").to_string() }
+                    }
                 }
                 button {
                     class: "outline secondary",

--- a/src/components/presenter_console_components.rs
+++ b/src/components/presenter_console_components.rs
@@ -122,6 +122,10 @@ pub fn PresenterConsolePage() -> Element {
     use_effect(move || {
         let current = running_presentations.read();
         if current.is_empty() {
+            // Drop the read guard BEFORE navigating — on web (single VirtualDom),
+            // nav.replace() triggers a synchronous re-render/diff that would
+            // attempt to borrow the same RefCell, causing a panic.
+            drop(current);
             if is_main_window {
                 if let Some(nav) = &nav {
                     nav.replace(crate::Route::Selection {});
@@ -131,7 +135,9 @@ pub fn PresenterConsolePage() -> Element {
         }
         if let Some(rp) = current.first() {
             if !rp.eq_ignoring_scroll(&running_presentation.peek()) {
-                running_presentation.set(rp.clone());
+                let rp = rp.clone();
+                drop(current);
+                running_presentation.set(rp);
             }
         }
     });

--- a/src/components/selection_components.rs
+++ b/src/components/selection_components.rs
@@ -331,6 +331,41 @@ pub fn Selection() -> Element {
                 }
             }
 
+            // Running presentation indicator bar
+            if !running_presentations.read().is_empty() {
+                div {
+                    class: "running-presentation-bar",
+                    span { { t!("selection.presentation_running").to_string() } }
+                    button {
+                        class: "outline",
+                        onclick: move |_| {
+                            presentation::update_presentation(
+                                &selected_items.read(),
+                                &mut running_presentations,
+                                &default_presentation_design_memo(),
+                                &default_song_slide_settings_memo(),
+                            );
+                        },
+                        { t!("selection.update_presentation").to_string() }
+                    }
+                    if settings.read().presenter_console_in_main_window && settings.read().show_presenter_console {
+                        button {
+                            onclick: move |_| {
+                                // Update the presentation with current selection before returning
+                                presentation::update_presentation(
+                                    &selected_items.read(),
+                                    &mut running_presentations,
+                                    &default_presentation_design_memo(),
+                                    &default_song_slide_settings_memo(),
+                                );
+                                nav.push(crate::Route::PresenterConsolePage {});
+                            },
+                            { t!("selection.return_to_presenter").to_string() }
+                        }
+                    }
+                }
+            }
+
             // Display search results if there are any and search_visible is true
             if search_visible() {
                 SearchResults {
@@ -522,14 +557,32 @@ pub fn Selection() -> Element {
                     },
                     button {
                         class: "primary smaller-buttons",
-                        onclick: move |_| start_presentation(&selected_items.read().clone(), &mut running_presentations, &default_presentation_design_memo(), &default_song_slide_settings_memo(), &settings.read()),
+                        onclick: move |_| {
+                            if running_presentations.read().is_empty() {
+                                start_presentation(&selected_items.read().clone(), &mut running_presentations, &default_presentation_design_memo(), &default_song_slide_settings_memo(), &settings.read());
+                            } else {
+                                presentation::update_presentation(
+                                    &selected_items.read(),
+                                    &mut running_presentations,
+                                    &default_presentation_design_memo(),
+                                    &default_song_slide_settings_memo(),
+                                );
+                                if settings.read().presenter_console_in_main_window && settings.read().show_presenter_console {
+                                    nav.push(crate::Route::PresenterConsolePage {});
+                                }
+                            }
+                        },
                         span {
                             class: "mobile-only",
                             Icon { icon: FaPlay }
                         }
                         span {
                             class: "desktop-only",
-                            { t!("selection.start_presentation").to_string() }
+                            if running_presentations.read().is_empty() {
+                                { t!("selection.start_presentation").to_string() }
+                            } else {
+                                { t!("selection.update_presentation").to_string() }
+                            }
                         }
                     }
                 }

--- a/src/components/selection_components.rs
+++ b/src/components/selection_components.rs
@@ -474,18 +474,6 @@ pub fn Selection() -> Element {
                                 selected_items: selected_items
                             }
                         }
-                        // Drop zone hint shown when dragging over
-                        if drag_over_source() {
-                            div {
-                                class: "drop-zone-hint",
-                                { t!("selection.drag_drop_active").to_string() }
-                            }
-                        } else {
-                            div {
-                                class: "drop-zone-hint",
-                                { t!("selection.drag_drop_hint").to_string() }
-                            }
-                        }
                     },
 
                     // The area where the selected elements are shown

--- a/src/components/selection_components.rs
+++ b/src/components/selection_components.rs
@@ -13,8 +13,8 @@ use crate::logic::settings::{Settings, default_sidebar_order, use_settings};
 use crate::logic::sourcefiles::SourceFile;
 #[cfg(target_arch = "wasm32")]
 use crate::logic::sync::{
-    SYNC_KEY_ACTIVE, SYNC_KEY_POSITION, SYNC_KEY_POSITION_FROM_CONSOLE, SYNC_KEY_PRESENTATION,
-    SYNC_KEY_QUIT,
+    SYNC_KEY_ACTIVE, SYNC_KEY_FILES, SYNC_KEY_POSITION, SYNC_KEY_POSITION_FROM_CONSOLE,
+    SYNC_KEY_PRESENTATION, SYNC_KEY_QUIT,
 };
 use crate::Route;
 use cantara_songlib::slides::SlideSettings;
@@ -1569,73 +1569,125 @@ fn start_presentation(
     default_slide_settings: &SlideSettings,
     settings_read: &Settings,
 ) {
-    if presentation::add_presentation(
+    // Build the presentation data without writing to any signal yet.
+    // On web, window.open() must be called BEFORE signal writes because
+    // window.open() can trigger synchronous browser callbacks (e.g. focus/blur)
+    // that re-enter the Dioxus diff engine. If signals are dirty at that point,
+    // the diff engine tries to process the dirty component whose scope is still
+    // borrowed from the current event handler, causing a "RefCell already
+    // borrowed" panic.
+    let Some(rp) = presentation::build_presentation(
         selected_items,
-        running_presentations,
         default_presentation_design,
         default_slide_settings,
-    )
-        .is_some()
-    {
-        let nav = navigator();
-        if settings_read.show_presenter_console {
-            // Store the presentation data in localStorage for the new-tab presentation
-            #[cfg(target_arch = "wasm32")]
+    ) else {
+        return;
+    };
+
+    let nav = navigator();
+    if settings_read.show_presenter_console {
+        // Store the presentation data in localStorage for the new-tab presentation
+        #[cfg(target_arch = "wasm32")]
+        {
+            if let Ok(json) = serde_json::to_string(&rp) {
+                let _ = web_sys::window()
+                    .and_then(|w| w.local_storage().ok().flatten())
+                    .map(|s| {
+                        let _ = s.set_item(SYNC_KEY_PRESENTATION, &json);
+                        let _ = s.set_item(SYNC_KEY_ACTIVE, "true");
+                        let _ = s.remove_item(SYNC_KEY_QUIT);
+                        let _ = s.remove_item(SYNC_KEY_POSITION);
+                        let _ = s.remove_item(SYNC_KEY_POSITION_FROM_CONSOLE);
+                    });
+            }
+
+            // Collect VFS files (e.g. PDFs) needed by the presentation and store
+            // them in localStorage so the new tab can populate its own VFS.
             {
-                if let Some(rp) = running_presentations.read().first() {
-                    if let Ok(json) = serde_json::to_string(rp) {
-                        let _ = web_sys::window()
-                            .and_then(|w| w.local_storage().ok().flatten())
-                            .map(|s| {
-                                let _ = s.set_item(SYNC_KEY_PRESENTATION, &json);
-                                let _ = s.set_item(SYNC_KEY_ACTIVE, "true");
-                                let _ = s.remove_item(SYNC_KEY_QUIT);
-                                let _ = s.remove_item(SYNC_KEY_POSITION);
-                                let _ = s.remove_item(SYNC_KEY_POSITION_FROM_CONSOLE);
-                            });
-                    }
-                }
-                // Open the presentation in a new browser tab.
-                // Derive the URL from window.location at runtime so that any deployment
-                // base path (e.g. /Cantara/ on GitHub Pages) is handled automatically.
-                if let Some(win) = web_sys::window() {
-                    let location = win.location();
-                    match (location.origin(), location.pathname()) {
-                        (Ok(origin), Ok(pathname)) => {
-                            // The Selection page is the root route "/". Stripping the
-                            // trailing slash gives the deployment base, e.g. "/Cantara"
-                            // for GitHub Pages or "" for local dev.
-                            let base = pathname.trim_end_matches('/');
-                            let url = format!("{}{}/presentation", origin, base);
-                            match win.open_with_url_and_target(&url, "_blank") {
-                                Ok(Some(_)) => {
-                                    // Successfully opened new tab/window.
-                                }
-                                Ok(None) | Err(_) => {
-                                    // Popup likely blocked or failed to open; inform the user.
-                                    let _ = win.alert_with_message(
-                                        "Unable to open the presentation in a new tab.\n\
-Please allow pop-ups for this site or open the presentation manually.",
+                use crate::logic::presentation::get_picture_path;
+                use crate::logic::settings::RepositoryType;
+                use cantara_songlib::slides::SlideContent;
+                use std::collections::HashMap;
+
+                let mut files: HashMap<String, String> = HashMap::new();
+                for chapter in &rp.presentation {
+                    for slide in &chapter.slides {
+                        if let SlideContent::SimplePicture(ref pic) = slide.slide_content {
+                            let path = get_picture_path(pic);
+                            let base_path = path.split('#').next().unwrap_or(&path).to_string();
+                            if base_path.to_lowercase().ends_with(".pdf")
+                                && !files.contains_key(&base_path)
+                            {
+                                if let Some(bytes) = RepositoryType::web_read_file(&base_path) {
+                                    files.insert(
+                                        base_path,
+                                        base64::Engine::encode(
+                                            &base64::engine::general_purpose::STANDARD,
+                                            &bytes,
+                                        ),
                                     );
                                 }
                             }
                         }
-                        _ => {
-                            // Location API unavailable (should not happen in a browser).
-                            let _ = win.alert_with_message(
-                                "Unable to determine the app URL. \
-Please open the presentation tab manually.",
-                            );
-                        }
+                    }
+                }
+                if !files.is_empty() {
+                    if let Ok(files_json) = serde_json::to_string(&files) {
+                        let _ = web_sys::window()
+                            .and_then(|w| w.local_storage().ok().flatten())
+                            .map(|s| s.set_item(SYNC_KEY_FILES, &files_json));
                     }
                 }
             }
-            // Navigate the current tab to the presenter console
-            nav.push(crate::Route::PresenterConsolePage {});
-        } else {
-            // No presenter console: start presentation directly in the same tab
-            nav.push(crate::Route::PresentationPage {});
+            // Open the presentation in a new browser tab.
+            // This MUST happen before the signal write below — see comment above.
+            // Derive the URL from window.location at runtime so that any deployment
+            // base path (e.g. /Cantara/ on GitHub Pages) is handled automatically.
+            if let Some(win) = web_sys::window() {
+                let location = win.location();
+                match (location.origin(), location.pathname()) {
+                    (Ok(origin), Ok(pathname)) => {
+                        // The Selection page is the root route "/". Stripping the
+                        // trailing slash gives the deployment base, e.g. "/Cantara"
+                        // for GitHub Pages or "" for local dev.
+                        let base = pathname.trim_end_matches('/');
+                        let url = format!("{}{}/presentation", origin, base);
+                        match win.open_with_url_and_target(&url, "_blank") {
+                            Ok(Some(_)) => {
+                                // Successfully opened new tab/window.
+                            }
+                            Ok(None) | Err(_) => {
+                                // Popup likely blocked or failed to open; inform the user.
+                                let _ = win.alert_with_message(
+                                    "Unable to open the presentation in a new tab.\n\
+Please allow pop-ups for this site or open the presentation manually.",
+                                );
+                            }
+                        }
+                    }
+                    _ => {
+                        // Location API unavailable (should not happen in a browser).
+                        let _ = win.alert_with_message(
+                            "Unable to determine the app URL. \
+Please open the presentation tab manually.",
+                        );
+                    }
+                }
+            }
         }
+
+        // NOW write to the signal — window.open() is done, so browser callbacks
+        // won't re-enter Dioxus while the signal is dirty.
+        running_presentations.write().clear();
+        running_presentations.write().push(rp);
+
+        // Navigate the current tab to the presenter console
+        nav.push(crate::Route::PresenterConsolePage {});
+    } else {
+        // No presenter console: write to signal and start presentation in same tab
+        running_presentations.write().clear();
+        running_presentations.write().push(rp);
+        nav.push(crate::Route::PresentationPage {});
     }
 }
 

--- a/src/logic/presentation.rs
+++ b/src/logic/presentation.rs
@@ -563,6 +563,61 @@ pub fn update_presentation(
         first.position = new_position;
         // Keep: is_black_screen, presentation_resolution, markdown_scroll_position
     }
+
+    // On web, immediately sync the updated state to localStorage so the synced
+    // presentation tab picks it up. Without this, the presenter console's
+    // use_effect might not be mounted yet (e.g. user is on the selection page),
+    // and the presentation tab would keep reading stale data from
+    // SYNC_KEY_POSITION_FROM_CONSOLE. We also clear SYNC_KEY_POSITION to
+    // prevent the presentation tab's old state from being read back by the
+    // presenter console and reverting the update.
+    #[cfg(target_arch = "wasm32")]
+    {
+        use super::settings::RepositoryType;
+        use super::sync::{SYNC_KEY_FILES, SYNC_KEY_POSITION, SYNC_KEY_POSITION_FROM_CONSOLE};
+        use std::collections::HashMap;
+
+        if let Some(rp) = running_presentations.peek().first() {
+            if let Ok(json) = serde_json::to_string(rp) {
+                // Collect VFS files (e.g. PDFs) so the synced tab can render them
+                let mut files: HashMap<String, String> = HashMap::new();
+                for chapter in &rp.presentation {
+                    for slide in &chapter.slides {
+                        if let SlideContent::SimplePicture(ref pic) = slide.slide_content {
+                            let path = get_picture_path(pic);
+                            let base_path = path.split('#').next().unwrap_or(&path).to_string();
+                            if base_path.to_lowercase().ends_with(".pdf")
+                                && !files.contains_key(&base_path)
+                            {
+                                if let Some(bytes) = RepositoryType::web_read_file(&base_path) {
+                                    files.insert(
+                                        base_path,
+                                        base64::Engine::encode(
+                                            &base64::engine::general_purpose::STANDARD,
+                                            &bytes,
+                                        ),
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+
+                let _ = web_sys::window()
+                    .and_then(|w| w.local_storage().ok().flatten())
+                    .map(|s| {
+                        let _ = s.set_item(SYNC_KEY_POSITION_FROM_CONSOLE, &json);
+                        let _ = s.remove_item(SYNC_KEY_POSITION);
+                        // Sync VFS files if there are any PDFs
+                        if !files.is_empty() {
+                            if let Ok(files_json) = serde_json::to_string(&files) {
+                                let _ = s.set_item(SYNC_KEY_FILES, &files_json);
+                            }
+                        }
+                    });
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/logic/presentation.rs
+++ b/src/logic/presentation.rs
@@ -3,13 +3,14 @@
 use super::{
     settings::PresentationDesign,
     sourcefiles::{SourceFile, SourceFileType},
-    states::{RunningPresentation, SelectedItemRepresentation, SlideChapter},
+    states::{RunningPresentation, RunningPresentationPosition, SelectedItemRepresentation, SlideChapter},
 };
 
 use cantara_songlib::importer::classic_song::slides_from_classic_song;
 use cantara_songlib::slides::{Slide, SlideContent, SimplePictureSlide, SingleLanguageMainContentSlide, SlideSettings};
 use dioxus::prelude::*;
 use std::{error::Error, path::{Path, PathBuf}};
+use uuid::Uuid;
 
 /// Prefix marker used to identify slides containing rendered Markdown HTML
 /// in the `main_text` field of a `SingleLanguageMainContentSlide`.
@@ -328,6 +329,7 @@ pub fn add_presentation(
 
         match create_presentation_slides(selected_item, &used_slide_settings) {
             Ok(slides) => presentation.push(SlideChapter {
+                id: Uuid::new_v4(),
                 slides,
                 source_file: selected_item.source_file.clone(),
                 presentation_design_option: Some(used_presentation_design),
@@ -372,6 +374,7 @@ pub fn create_single_item_presentation(
         .unwrap_or_default();
 
     let chapter = SlideChapter {
+        id: Uuid::new_v4(),
         slides,
         source_file: selected_item.source_file.clone(),
         presentation_design_option: Some(used_presentation_design),
@@ -407,6 +410,143 @@ pub fn create_amazing_grace_presentation(
     );
 
     RunningPresentation::new(vec![slide_chapter])
+}
+
+/// Updates a running presentation in-place by regenerating slide chapters
+/// from the current selection, while preserving the viewing position.
+///
+/// Chapters are always fully regenerated from the selected items (so changes
+/// to settings like style or max lines per slide take effect). The current
+/// viewing position is restored by matching the old chapter's UUID to the
+/// new chapter set. If the current chapter was removed, the position falls
+/// back to the first chapter or `None` if no chapters remain.
+pub fn update_presentation(
+    selected_items: &[SelectedItemRepresentation],
+    running_presentations: &mut Signal<Vec<RunningPresentation>>,
+    default_presentation_design: &PresentationDesign,
+    default_slide_settings: &SlideSettings,
+) {
+    // Must have a running presentation to update
+    let Some(old_rp) = running_presentations.peek().first().cloned() else {
+        return;
+    };
+
+    // Remember current position for restoration
+    let old_position = old_rp.position.clone();
+    let old_chapter_id = old_position.as_ref().and_then(|pos| {
+        old_rp.presentation.get(pos.chapter()).map(|ch| ch.id)
+    });
+    let old_chapter_slide = old_position
+        .as_ref()
+        .map(|pos| pos.chapter_slide())
+        .unwrap_or(0);
+
+    // Generate new chapters from current selection.
+    // Each chapter gets a fresh UUID — we do NOT reuse old UUIDs because the
+    // user may have changed settings (style, max lines, etc.) and the slides
+    // are fully regenerated. The old UUID is only used to find which new
+    // chapter corresponds to the one the user was viewing.
+    let mut new_chapters: Vec<SlideChapter> = vec![];
+    // Build a mapping from source_file.path to old chapter id for position tracking.
+    // We use an index to handle duplicate paths (e.g. multiple inline markdown items).
+    let mut old_path_ids: Vec<(std::path::PathBuf, Uuid)> = old_rp
+        .presentation
+        .iter()
+        .map(|ch| (ch.source_file.path.clone(), ch.id))
+        .collect();
+
+    for selected_item in selected_items {
+        let used_presentation_design = selected_item
+            .presentation_design_option
+            .clone()
+            .unwrap_or(default_presentation_design.clone());
+
+        let used_slide_settings = selected_item
+            .slide_settings_option
+            .clone()
+            .unwrap_or(default_slide_settings.clone());
+
+        match create_presentation_slides(selected_item, &used_slide_settings) {
+            Ok(slides) => {
+                // Try to find a matching old chapter by source_file path to carry
+                // over its UUID for position tracking. Remove it from the list so
+                // duplicate paths match in order.
+                let carried_id =
+                    if let Some(pos) = old_path_ids.iter().position(|(p, _)| {
+                        *p == selected_item.source_file.path
+                    }) {
+                        let (_, id) = old_path_ids.remove(pos);
+                        Some(id)
+                    } else {
+                        None
+                    };
+
+                new_chapters.push(SlideChapter {
+                    id: Uuid::new_v4(),
+                    slides,
+                    source_file: selected_item.source_file.clone(),
+                    presentation_design_option: Some(used_presentation_design),
+                    slide_settings_option: Some(used_slide_settings),
+                    timer_settings_option: selected_item.timer_settings_option.clone(),
+                    transition_option: selected_item.transition_effect,
+                });
+
+                // Store the carried_id alongside the new chapter index for position lookup
+                if let Some(old_id) = carried_id {
+                    let new_ch = new_chapters.last_mut().unwrap();
+                    // Temporarily reuse the old UUID so we can find this chapter below.
+                    // This is safe because we generate a new UUID right after position
+                    // restoration is complete.
+                    new_ch.id = old_id;
+                }
+            }
+            Err(_) => { /* skip failed items */ }
+        }
+    }
+
+    // Determine new position
+    let new_position = if new_chapters.is_empty() {
+        None
+    } else if let Some(target_id) = old_chapter_id {
+        // Try to find the old chapter in the new set by its carried UUID
+        if let Some(new_ch_idx) = new_chapters.iter().position(|ch| ch.id == target_id) {
+            let slide_count = new_chapters[new_ch_idx].slides.len();
+            if slide_count == 0 {
+                // Chapter exists but has no slides — fall back to first chapter
+                RunningPresentationPosition::new(&new_chapters)
+            } else {
+                let clamped_slide = old_chapter_slide.min(slide_count - 1);
+                // Recompute slide_total
+                let mut total: usize = 0;
+                for i in 0..new_ch_idx {
+                    total += new_chapters[i].slides.len();
+                }
+                total += clamped_slide;
+                Some(RunningPresentationPosition::from_raw(
+                    new_ch_idx,
+                    clamped_slide,
+                    total,
+                ))
+            }
+        } else {
+            // Current chapter was deleted; fall back to first chapter
+            RunningPresentationPosition::new(&new_chapters)
+        }
+    } else {
+        RunningPresentationPosition::new(&new_chapters)
+    };
+
+    // Now assign fresh UUIDs to all chapters so they don't carry stale old IDs
+    for ch in &mut new_chapters {
+        ch.id = Uuid::new_v4();
+    }
+
+    // Update the running presentation in-place (preserves window state)
+    if let Some(first) = running_presentations.write().first_mut() {
+        first.presentation = new_chapters;
+        first.position = new_position;
+        // Keep: is_black_screen, presentation_resolution, markdown_scroll_position
+    }
 }
 
 #[cfg(test)]

--- a/src/logic/presentation.rs
+++ b/src/logic/presentation.rs
@@ -302,18 +302,15 @@ fn create_presentation_slides(
 
 /// Adds a presentation to the global running presentations signal
 /// Returns the number (id) of the created presentation
-pub fn add_presentation(
+/// Builds a [RunningPresentation] from the selected items without writing to
+/// any signal. This is the pure computation step used by [add_presentation]
+/// and by the web `start_presentation` (which needs the data before opening
+/// the presentation tab, i.e. before any signal writes).
+pub fn build_presentation(
     selected_items: &Vec<SelectedItemRepresentation>,
-    running_presentations: &mut Signal<Vec<RunningPresentation>>,
     default_presentation_design: &PresentationDesign,
     default_slide_settings: &SlideSettings,
-) -> Option<usize> {
-    // Right now, we only allow one running presentation at the same time.
-    // Later, Cantara is going to support multiple presentations.
-    if running_presentations.len() > 0 {
-        running_presentations.write().clear();
-    }
-
+) -> Option<RunningPresentation> {
     let mut presentation: Vec<SlideChapter> = vec![];
 
     for selected_item in selected_items {
@@ -344,9 +341,28 @@ pub fn add_presentation(
     }
 
     if !presentation.is_empty() {
+        Some(RunningPresentation::new(presentation))
+    } else {
+        None
+    }
+}
+
+pub fn add_presentation(
+    selected_items: &Vec<SelectedItemRepresentation>,
+    running_presentations: &mut Signal<Vec<RunningPresentation>>,
+    default_presentation_design: &PresentationDesign,
+    default_slide_settings: &SlideSettings,
+) -> Option<usize> {
+    // Right now, we only allow one running presentation at the same time.
+    // Later, Cantara is going to support multiple presentations.
+    if running_presentations.len() > 0 {
+        running_presentations.write().clear();
+    }
+
+    if let Some(rp) = build_presentation(selected_items, default_presentation_design, default_slide_settings) {
         running_presentations
             .write()
-            .push(RunningPresentation::new(presentation));
+            .push(rp);
         return Some(running_presentations.len() - 1);
     }
 

--- a/src/logic/presentation.rs
+++ b/src/logic/presentation.rs
@@ -333,6 +333,7 @@ pub fn build_presentation(
                 slide_settings_option: Some(used_slide_settings),
                 timer_settings_option: selected_item.timer_settings_option.clone(),
                 transition_option: selected_item.transition_effect,
+                inline_markdown: selected_item.inline_markdown.clone(),
             }),
             Err(_) => {
                 // TODO: Implement error handling, the user should get a message if an error occurs...
@@ -397,6 +398,7 @@ pub fn create_single_item_presentation(
         slide_settings_option: Some(used_slide_settings),
         timer_settings_option: selected_item.timer_settings_option.clone(),
         transition_option: selected_item.transition_effect,
+        inline_markdown: selected_item.inline_markdown.clone(),
     };
 
     RunningPresentation::new(vec![chapter])
@@ -464,13 +466,29 @@ fn apply_presentation_update(
     // are fully regenerated. The old UUID is only used to find which new
     // chapter corresponds to the one the user was viewing.
     let mut new_chapters: Vec<SlideChapter> = vec![];
-    // Build a mapping from source_file.path to old chapter id for position tracking.
-    // We use an index to handle duplicate paths (e.g. multiple inline markdown items).
-    let mut old_path_ids: Vec<(std::path::PathBuf, Uuid)> = old_rp
-        .presentation
-        .iter()
-        .map(|ch| (ch.source_file.path.clone(), ch.id))
-        .collect();
+
+    // Build a fingerprint → queue mapping for position tracking.
+    //
+    // The fingerprint is (source_file.path, source_file.md5_hash, inline_markdown).
+    // Using all three fields correctly distinguishes items that share the same path
+    // but have different content (e.g. two inline-text items, or a file whose hash
+    // changed). For truly identical items (same fingerprint) we use FIFO order, which
+    // is the best possible behaviour when the items are indistinguishable.
+    //
+    // This replaces the old Vec<(PathBuf, Uuid)> + linear-scan approach, which
+    // matched only by path and could carry the wrong UUID to the wrong chapter
+    // when the same path appeared more than once and the selection was reordered.
+    type ChapterKey = (std::path::PathBuf, Option<String>, Option<String>);
+    let mut old_key_ids: std::collections::HashMap<ChapterKey, std::collections::VecDeque<Uuid>> =
+        std::collections::HashMap::new();
+    for ch in &old_rp.presentation {
+        let key: ChapterKey = (
+            ch.source_file.path.clone(),
+            ch.source_file.md5_hash.clone(),
+            ch.inline_markdown.clone(),
+        );
+        old_key_ids.entry(key).or_default().push_back(ch.id);
+    }
 
     for selected_item in selected_items {
         let used_presentation_design = selected_item
@@ -485,37 +503,28 @@ fn apply_presentation_update(
 
         match create_presentation_slides(selected_item, &used_slide_settings) {
             Ok(slides) => {
-                // Try to find a matching old chapter by source_file path to carry
-                // over its UUID for position tracking. Remove it from the list so
-                // duplicate paths match in order.
-                let carried_id =
-                    if let Some(pos) = old_path_ids.iter().position(|(p, _)| {
-                        *p == selected_item.source_file.path
-                    }) {
-                        let (_, id) = old_path_ids.remove(pos);
-                        Some(id)
-                    } else {
-                        None
-                    };
+                // Carry the old UUID for this content fingerprint (FIFO within
+                // identical fingerprints) so we can restore the viewing position.
+                let key: ChapterKey = (
+                    selected_item.source_file.path.clone(),
+                    selected_item.source_file.md5_hash.clone(),
+                    selected_item.inline_markdown.clone(),
+                );
+                let carried_id = old_key_ids.get_mut(&key).and_then(|q| q.pop_front());
 
                 new_chapters.push(SlideChapter {
-                    id: Uuid::new_v4(),
+                    // Temporarily use the carried old UUID so we can find this
+                    // chapter in the position-restore step below. A fresh UUID is
+                    // assigned after that step completes.
+                    id: carried_id.unwrap_or_else(Uuid::new_v4),
                     slides,
                     source_file: selected_item.source_file.clone(),
                     presentation_design_option: Some(used_presentation_design),
                     slide_settings_option: Some(used_slide_settings),
                     timer_settings_option: selected_item.timer_settings_option.clone(),
                     transition_option: selected_item.transition_effect,
+                    inline_markdown: selected_item.inline_markdown.clone(),
                 });
-
-                // Store the carried_id alongside the new chapter index for position lookup
-                if let Some(old_id) = carried_id {
-                    let new_ch = new_chapters.last_mut().unwrap();
-                    // Temporarily reuse the old UUID so we can find this chapter below.
-                    // This is safe because we generate a new UUID right after position
-                    // restoration is complete.
-                    new_ch.id = old_id;
-                }
             }
             Err(_) => { /* skip failed items */ }
         }
@@ -949,6 +958,38 @@ mod tests {
         assert_eq!(pos.chapter(), 0, "still in chapter 0");
         assert_eq!(pos.chapter_slide(), 0, "clamped to slide 0 (only slide)");
         assert_eq!(pos.slide_total(), 0);
+    }
+
+    /// (2b) Two items share the same path but have different inline content.
+    /// After the selection is reordered the position must follow the correct
+    /// item (the one the user was actually viewing), not slide to the other.
+    #[test]
+    fn test_update_preserves_position_when_duplicate_paths_reordered() {
+        // Both items share path "shared.md" but have different content (1 vs 2 slides).
+        let item_one = inline_md_item("shared.md", "# Solo");
+        let item_two = inline_md_item("shared.md", "# First\n\n---\n\n# Second");
+
+        let items_initial = [item_one.clone(), item_two.clone()];
+        let mut rp = build_rp(&items_initial);
+        // Navigate to chapter 1 (item_two), slide 1
+        rp.jump_to(1, 1);
+        assert_eq!(rp.position.as_ref().unwrap().chapter(), 1);
+        assert_eq!(rp.position.as_ref().unwrap().chapter_slide(), 1);
+
+        // Regenerate with the order swapped: [item_two, item_one]
+        let items_swapped = [item_two, item_one];
+        let updated = apply_presentation_update(
+            rp,
+            &items_swapped,
+            &PresentationDesign::default(),
+            &SlideSettings::default(),
+        );
+
+        let pos = updated.position.expect("position should survive reorder");
+        // item_two is now chapter 0; user should still be on its slide 1
+        assert_eq!(pos.chapter(), 0, "position should follow item_two to its new index");
+        assert_eq!(pos.chapter_slide(), 1, "slide within item_two should be preserved");
+        assert_eq!(pos.slide_total(), 1, "slide_total = 0 slides before + slide 1");
     }
 
     /// (3) When the currently active chapter is removed from the selection

--- a/src/logic/presentation.rs
+++ b/src/logic/presentation.rs
@@ -436,17 +436,18 @@ pub fn create_amazing_grace_presentation(
 /// viewing position is restored by matching the old chapter's UUID to the
 /// new chapter set. If the current chapter was removed, the position falls
 /// back to the first chapter or `None` if no chapters remain.
-pub fn update_presentation(
+/// Pure computation for [`update_presentation`]: regenerates chapters from
+/// `selected_items` and computes the new position, preserving all other fields
+/// from `old_rp` (black screen state, resolution, scroll position).
+///
+/// Separated from the signal-mutating wrapper so it can be unit-tested without
+/// a Dioxus runtime.
+fn apply_presentation_update(
+    old_rp: RunningPresentation,
     selected_items: &[SelectedItemRepresentation],
-    running_presentations: &mut Signal<Vec<RunningPresentation>>,
     default_presentation_design: &PresentationDesign,
     default_slide_settings: &SlideSettings,
-) {
-    // Must have a running presentation to update
-    let Some(old_rp) = running_presentations.peek().first().cloned() else {
-        return;
-    };
-
+) -> RunningPresentation {
     // Remember current position for restoration
     let old_position = old_rp.position.clone();
     let old_chapter_id = old_position.as_ref().and_then(|pos| {
@@ -557,10 +558,38 @@ pub fn update_presentation(
         ch.id = Uuid::new_v4();
     }
 
+    RunningPresentation {
+        presentation: new_chapters,
+        position: new_position,
+        // Preserve fields that are unrelated to content regeneration
+        is_black_screen: old_rp.is_black_screen,
+        presentation_resolution: old_rp.presentation_resolution,
+        markdown_scroll_position: old_rp.markdown_scroll_position,
+    }
+}
+
+pub fn update_presentation(
+    selected_items: &[SelectedItemRepresentation],
+    running_presentations: &mut Signal<Vec<RunningPresentation>>,
+    default_presentation_design: &PresentationDesign,
+    default_slide_settings: &SlideSettings,
+) {
+    // Must have a running presentation to update
+    let Some(old_rp) = running_presentations.peek().first().cloned() else {
+        return;
+    };
+
+    let updated = apply_presentation_update(
+        old_rp,
+        selected_items,
+        default_presentation_design,
+        default_slide_settings,
+    );
+
     // Update the running presentation in-place (preserves window state)
     if let Some(first) = running_presentations.write().first_mut() {
-        first.presentation = new_chapters;
-        first.position = new_position;
+        first.presentation = updated.presentation;
+        first.position = updated.position;
         // Keep: is_black_screen, presentation_resolution, markdown_scroll_position
     }
 
@@ -830,5 +859,123 @@ mod tests {
         // &amp;lt; should decode to &lt; (not <)
         assert_eq!(html_to_plain_text("&amp;lt;"), "&lt;");
         assert_eq!(html_to_plain_text("plain text"), "plain text");
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers for update_presentation tests
+    // -------------------------------------------------------------------------
+
+    fn inline_md_item(path: &str, markdown: &str) -> SelectedItemRepresentation {
+        SelectedItemRepresentation {
+            source_file: SourceFile {
+                name: path.to_string(),
+                path: PathBuf::from_str(path).unwrap(),
+                file_type: crate::logic::sourcefiles::SourceFileType::Markdown,
+                md5_hash: None,
+            },
+            presentation_design_option: None,
+            slide_settings_option: None,
+            inline_markdown: Some(markdown.to_string()),
+            timer_settings_option: None,
+            transition_effect: Default::default(),
+        }
+    }
+
+    /// Build a `RunningPresentation` from inline-markdown items (no disk I/O).
+    fn build_rp(items: &[SelectedItemRepresentation]) -> RunningPresentation {
+        let design = PresentationDesign::default();
+        let settings = SlideSettings::default();
+        let rp = build_presentation(&items.to_vec(), &design, &settings);
+        rp.expect("build_presentation should succeed for inline markdown items")
+    }
+
+    // -------------------------------------------------------------------------
+    // update_presentation tests
+    // -------------------------------------------------------------------------
+
+    /// (1) When the same chapters are regenerated the position (chapter index
+    /// and slide-within-chapter) is preserved exactly.
+    #[test]
+    fn test_update_preserves_position_on_regeneration() {
+        // Chapter 0: 2 slides, Chapter 1: 3 slides
+        let item_a = inline_md_item("a.md", "# S1\n\n---\n\n# S2");
+        let item_b = inline_md_item("b.md", "# S1\n\n---\n\n# S2\n\n---\n\n# S3");
+        let items = [item_a.clone(), item_b.clone()];
+
+        let mut rp = build_rp(&items);
+        // Navigate to chapter 1, slide 1  (slide_total = 2 + 1 = 3)
+        rp.jump_to(1, 1);
+        assert_eq!(rp.position.as_ref().unwrap().chapter(), 1);
+        assert_eq!(rp.position.as_ref().unwrap().chapter_slide(), 1);
+
+        let updated = apply_presentation_update(
+            rp,
+            &items,
+            &PresentationDesign::default(),
+            &SlideSettings::default(),
+        );
+
+        let pos = updated.position.expect("position should survive regeneration");
+        assert_eq!(pos.chapter(), 1, "chapter index should be preserved");
+        assert_eq!(pos.chapter_slide(), 1, "slide-within-chapter should be preserved");
+        // slide_total = chapter-0 slides (2) + chapter_slide (1)
+        assert_eq!(pos.slide_total(), 3, "slide_total should be recomputed correctly");
+    }
+
+    /// (2) When the chapter is regenerated with fewer slides than the current
+    /// slide index, the position is clamped to the last available slide.
+    #[test]
+    fn test_update_clamps_slide_index_when_fewer_slides() {
+        // Chapter 0: starts with 3 slides; user is on slide 2
+        let item_3slides = inline_md_item("a.md", "# S1\n\n---\n\n# S2\n\n---\n\n# S3");
+        let items_initial = [item_3slides];
+
+        let mut rp = build_rp(&items_initial);
+        rp.jump_to(0, 2); // last slide
+        assert_eq!(rp.position.as_ref().unwrap().chapter_slide(), 2);
+
+        // Regenerate with only 1 slide for the same chapter
+        let item_1slide = inline_md_item("a.md", "# Only");
+        let items_updated = [item_1slide];
+
+        let updated = apply_presentation_update(
+            rp,
+            &items_updated,
+            &PresentationDesign::default(),
+            &SlideSettings::default(),
+        );
+
+        let pos = updated.position.expect("position should still exist");
+        assert_eq!(pos.chapter(), 0, "still in chapter 0");
+        assert_eq!(pos.chapter_slide(), 0, "clamped to slide 0 (only slide)");
+        assert_eq!(pos.slide_total(), 0);
+    }
+
+    /// (3) When the currently active chapter is removed from the selection
+    /// the position falls back to the first chapter.
+    #[test]
+    fn test_update_falls_back_to_first_chapter_when_current_removed() {
+        // Two chapters; user is on chapter 1
+        let item_a = inline_md_item("a.md", "# SlideA");
+        let item_b = inline_md_item("b.md", "# SlideB");
+        let items_initial = [item_a.clone(), item_b.clone()];
+
+        let mut rp = build_rp(&items_initial);
+        rp.jump_to(1, 0);
+        assert_eq!(rp.position.as_ref().unwrap().chapter(), 1);
+
+        // Regenerate with only chapter A (chapter B is gone)
+        let items_updated = [item_a];
+
+        let updated = apply_presentation_update(
+            rp,
+            &items_updated,
+            &PresentationDesign::default(),
+            &SlideSettings::default(),
+        );
+
+        let pos = updated.position.expect("position should fall back, not be None");
+        assert_eq!(pos.chapter(), 0, "should fall back to first chapter");
+        assert_eq!(pos.chapter_slide(), 0);
     }
 }

--- a/src/logic/states.rs
+++ b/src/logic/states.rs
@@ -421,6 +421,13 @@ pub struct SlideChapter {
     /// The transition effect for this chapter.
     #[serde(default)]
     pub transition_option: SlideTransition,
+    /// Inline markdown content, if this chapter was created from an inline
+    /// (spontaneous) markdown item rather than a file on disk.
+    /// Stored here so `update_presentation` can use it as part of the chapter
+    /// fingerprint to distinguish two items that share the same `source_file.path`
+    /// but have different content (e.g. two inline-text items).
+    #[serde(default)]
+    pub inline_markdown: Option<String>,
 }
 
 impl SlideChapter {
@@ -438,6 +445,7 @@ impl SlideChapter {
             slide_settings_option: slide_settings,
             timer_settings_option: None,
             transition_option: SlideTransition::default(),
+            inline_markdown: None,
         }
     }
 }

--- a/src/logic/states.rs
+++ b/src/logic/states.rs
@@ -201,26 +201,22 @@ impl RunningPresentation {
     }
 
     pub fn get_current_slide(&self) -> Option<Slide> {
-        self.position.clone().map(|pos| {
+        self.position.as_ref().and_then(|pos| {
             self.presentation
-                .get(pos.chapter())
-                .unwrap()
+                .get(pos.chapter())?
                 .slides
                 .get(pos.chapter_slide())
-                .unwrap()
-                .clone()
+                .cloned()
         })
     }
 
     pub fn get_current_presentation_design(&self) -> PresentationDesign {
-        match self.position.clone() {
+        match self.position.as_ref() {
             Some(pos) => self
                 .presentation
                 .get(pos.chapter())
-                .unwrap()
-                .presentation_design_option
-                .clone()
-                .unwrap_or(PresentationDesign::default()),
+                .and_then(|ch| ch.presentation_design_option.clone())
+                .unwrap_or_default(),
             None => PresentationDesign::default(),
         }
     }
@@ -245,14 +241,12 @@ impl RunningPresentation {
     }
 
     pub fn get_current_slide_settings(&self) -> SlideSettings {
-        match self.position.clone() {
+        match self.position.as_ref() {
             Some(pos) => self
                 .presentation
                 .get(pos.chapter())
-                .unwrap()
-                .slide_settings_option
-                .clone()
-                .unwrap_or(SlideSettings::default()),
+                .and_then(|ch| ch.slide_settings_option.clone())
+                .unwrap_or_default(),
             None => SlideSettings::default(),
         }
     }
@@ -354,11 +348,12 @@ impl RunningPresentationPosition {
     /// Tries to go to the next position if it exists (and returns okay),
     /// if the next position does not exist, an error will be returned.
     pub fn try_next(&mut self, presentation: &Vec<SlideChapter>) -> Result<(), ()> {
-        if self.chapter_slide < self.cur_chapter_slide_length(presentation) - 1 {
+        let chapter_len = self.cur_chapter_slide_length(presentation);
+        if chapter_len > 0 && self.chapter_slide < chapter_len - 1 {
             self.chapter_slide += 1;
             self.slide_total += 1;
             Ok(())
-        } else if self.chapter < presentation.len() - 1 {
+        } else if self.chapter < presentation.len().saturating_sub(1) {
             self.chapter += 1;
             self.chapter_slide = 0;
             self.slide_total += 1;
@@ -377,7 +372,7 @@ impl RunningPresentationPosition {
             Ok(())
         } else if self.chapter > 0 {
             self.chapter -= 1;
-            self.chapter_slide = self.cur_chapter_slide_length(presentation) - 1;
+            self.chapter_slide = self.cur_chapter_slide_length(presentation).saturating_sub(1);
             self.slide_total -= 1;
             Ok(())
         } else {
@@ -387,7 +382,10 @@ impl RunningPresentationPosition {
 
     /// Helper function for getting the current slide length
     fn cur_chapter_slide_length(&self, presentation: &Vec<SlideChapter>) -> usize {
-        presentation.get(self.chapter).unwrap().slides.len()
+        presentation
+            .get(self.chapter)
+            .map(|ch| ch.slides.len())
+            .unwrap_or(0)
     }
 
     /// Get the number of the current chapter

--- a/src/logic/states.rs
+++ b/src/logic/states.rs
@@ -2,6 +2,7 @@ use std::{fs, path::PathBuf};
 
 use dioxus::prelude::*;
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 use super::{settings::{PresentationDesign, SlideTimerSettings, SlideTransition}, sourcefiles::SourceFile};
 use cantara_songlib::slides::{Slide, SlideSettings};
@@ -327,6 +328,16 @@ pub struct RunningPresentationPosition {
 }
 
 impl RunningPresentationPosition {
+    /// Creates a position from raw values. Used when restoring position
+    /// after a presentation update.
+    pub fn from_raw(chapter: usize, chapter_slide: usize, slide_total: usize) -> Self {
+        RunningPresentationPosition {
+            chapter,
+            chapter_slide,
+            slide_total,
+        }
+    }
+
     /// Creates a new position if there is at least one slide available
     pub fn new(presentation: &Vec<SlideChapter>) -> Option<Self> {
         if !presentation.is_empty() && !presentation.first().unwrap().slides.is_empty() {
@@ -398,6 +409,10 @@ impl RunningPresentationPosition {
 /// Contains slide, the source file and the presentation design for each chapter (e.g. a song)
 #[derive(Clone, PartialEq, Serialize, Deserialize)]
 pub struct SlideChapter {
+    /// Stable identifier for matching chapters across presentation updates.
+    /// Generated once at slide generation time.
+    #[serde(default = "Uuid::new_v4")]
+    pub id: Uuid,
     pub slides: Vec<Slide>,
     pub source_file: SourceFile,
     pub presentation_design_option: Option<PresentationDesign>,
@@ -418,6 +433,7 @@ impl SlideChapter {
         slide_settings: Option<SlideSettings>,
     ) -> Self {
         SlideChapter {
+            id: Uuid::new_v4(),
             slides,
             source_file,
             presentation_design_option: presentation_design,

--- a/src/logic/sync.rs
+++ b/src/logic/sync.rs
@@ -22,3 +22,7 @@ pub const SYNC_KEY_POSITION_FROM_CONSOLE: &str = "cantara-sync-position-from-con
 
 /// localStorage key for synchronizing markdown scroll position across tabs.
 pub const SYNC_KEY_SCROLL_POSITION: &str = "cantara-sync-scroll-position";
+
+/// localStorage key holding base64-encoded VFS file data (e.g. PDFs) needed by
+/// the presentation tab. The value is a JSON map of `{ path: base64_data }`.
+pub const SYNC_KEY_FILES: &str = "cantara-sync-files";


### PR DESCRIPTION
This pull request implements live updates for running presentations. Elements can be added, removed or edited and will be applied live without the need of restarting the presentation.